### PR TITLE
Replace default shell and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ If you found that you're using `ffmpeg-free` then, you can replace it with
 sudo dnf install ffmpeg --allowerasing
 ```
 
+Do consult to your respective distro on how to install required codec
+for MP4.
+
 ### "Input file not found" error
 
 Check if the file path is correct

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Before using this script, make sure you have the following installed:
   - Mac: `brew install ffmpeg`
   - Ubuntu/Debian: `sudo apt-get install ffmpeg`
   - CentOS/RHEL: `sudo yum install ffmpeg`
-- **zsh**: Z shell (the script uses zsh as interpreter)
-  - Mac: Comes pre-installed
-  - Ubuntu/Debian: `sudo apt-get install zsh`
-  - CentOS/RHEL: `sudo yum install zsh`
+
+> For Centos/RHEL, you need to enable RPMFusion and EPEL. Read more https://rpmfusion.org/Configuration
+
 - **awk**: Should be pre-installed on most Unix-like systems
 
 ## Installation
@@ -89,7 +88,25 @@ Uses ffmpeg to:
 Make sure the script has execute permissions
 Verify that ffmpeg is installed and in your PATH
 
+### Black screen video output
 
+This usually happen because the required video codec is not fully compatible.
+For instance, in Centos if we use `ffmpeg-free` it will be able to convert
+the video to MP4 but you'll notice output has audio but with only black screen.
+
+If this happen, try check whether you're using `ffmpeg` or `ffmpeg-free` by 
+using this command
+
+```sh
+rpm -qa | grep ffmpeg
+```
+
+If you found that you're using `ffmpeg-free` then, you can replace it with 
+`ffmpeg` instead.
+
+```sh
+sudo dnf install ffmpeg --allowerasing
+```
 
 ### "Input file not found" error
 

--- a/convert_video.sh
+++ b/convert_video.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 
 # Function to print usage
 print_usage() {


### PR DESCRIPTION
## Replace ZSH with SH

All Linux/Unix based operating system already have shell installed as its main tool to interact with it. Installing another shell just to run specific script is redundant, though hacker is competent to make a simple change, it's better to use the POSIX shell as the default so it can run on different shell environment.

Although there is no guarantee it will run on _every_ machine, `sh` is more widely used on widely used Linux/Unix-based operating system

> it is often easy to write a script, but it can be more challenging to write a script that consistently works well.
>
> -- [Apple](https://developer.apple.com/library/archive/documentation/OpenSource/Conceptual/ShellScripting/shell_scripts/shell_scripts.html#//apple_ref/doc/uid/TP40004268-CH237-SW3)

Can you help test it?

## Include notes on Centos/RHEL installation

`ffmpeg` does not exist in standard repository, so users need to add another repository, `rpmfusion` and `epel` to be able to install `ffmpeg` using `dnf` or `yum`.

## Troubleshoot on black screen output

There may be the case when converting the video is successful but it will give an unexpected output, like black screen.
I've added a step on resolving it for Centos since that's what I'm currently using. Yet I also added a note that basically it happens
due to missing codec.